### PR TITLE
구글, 카카오 로그인 관련

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
             keyPassword daegu_dot
         }
         debug {
-            storeFile file(snsaccount)
+            storeFile file('C:\\Users\\kdi43\\Desktop\\snsaccount.jks')
             storePassword daegu_dot
             keyAlias key0
             keyPassword daegu_dot

--- a/app/src/main/java/com/kop/daegudot/Login/KakaoLogin/KakaoLoginHandler.java
+++ b/app/src/main/java/com/kop/daegudot/Login/KakaoLogin/KakaoLoginHandler.java
@@ -18,6 +18,7 @@ import com.kop.daegudot.MainActivity;
 import com.kop.daegudot.Network.RestApiService;
 import com.kop.daegudot.Network.RestfulAdapter;
 import com.kop.daegudot.Network.User.UserOauth;
+import com.kop.daegudot.Network.User.UserOauthResponse;
 import com.kop.daegudot.Network.User.UserResponseStatus;
 
 import io.reactivex.Observable;
@@ -62,7 +63,7 @@ public class KakaoLoginHandler {
         if (throwable != null) {
             // 로그인 실패
             Log.d("KakaoCallback", throwable.getLocalizedMessage());
-            Toast.makeText(mContext, "다시 시도해주세요", Toast.LENGTH_SHORT).show();
+            Toast.makeText(mContext, "다시 시도해주세요.", Toast.LENGTH_SHORT).show();
         }
         return null;
     };
@@ -74,12 +75,12 @@ public class KakaoLoginHandler {
                 Toast.makeText(mContext, "카카오 로그인에 성공하였습니다.", Toast.LENGTH_SHORT).show();
             }
             else if (user != null) {
-                Log.d(TAG, "User id: " + user.getId() +
+                /*Log.d(TAG, "User id: " + user.getId() +
                             "\nUser Email: " + user.getKakaoAccount().getEmail() +
                             "\nUser Nickname: " + user.getKakaoAccount().getProfile().getNickname());
                 
                 mEmail = user.getKakaoAccount().getEmail();
-                mNickname = user.getKakaoAccount().getProfile().getNickname();
+                mNickname = user.getKakaoAccount().getProfile().getNickname();*/
 
                 selectEmail(mEmail);
                 //updateUI(true);
@@ -100,19 +101,23 @@ public class KakaoLoginHandler {
             ((LoginActivity) mContext).finish();
         }
     }
-    //구글 인증 처리
+    //카카오 인증 처리
     private void oauthKakao(UserOauth userOauth) {
         RestfulAdapter restfulAdapter = RestfulAdapter.getInstance();
         RestApiService service =  restfulAdapter.getServiceApi(null);
-        Observable<Long> observable = service.oauthKakao(userOauth);
+        Observable<UserOauthResponse> observable = service.oauthKakao(userOauth);
 
         mCompositeDisposable.add(observable.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(new DisposableObserver<Long>() {
+                .subscribeWith(new DisposableObserver<UserOauthResponse>() {
                     @Override
-                    public void onNext(Long response) {
+                    public void onNext(UserOauthResponse response) {
                         Log.d("USER_KAKAO", userOauth.oauthToken);
-                        if(response == 1L) Toast.makeText(mContext, "카카오 인증이 완료되었습니다.", Toast.LENGTH_SHORT).show();
+                        if(response.status == 1L){
+                            Toast.makeText(mContext, "카카오 인증이 완료되었습니다.", Toast.LENGTH_SHORT).show();
+                            mEmail = response.email;
+                            mNickname = response.nickname;
+                        }
                         else Toast.makeText(mContext, "카카오 인증에 실패하였습니다.", Toast.LENGTH_SHORT).show();
                     }
 

--- a/app/src/main/java/com/kop/daegudot/Login/LoginActivity.java
+++ b/app/src/main/java/com/kop/daegudot/Login/LoginActivity.java
@@ -33,6 +33,7 @@ import com.kop.daegudot.MainActivity;
 import com.kop.daegudot.Network.RestApiService;
 import com.kop.daegudot.Network.RestfulAdapter;
 import com.kop.daegudot.Network.User.UserOauth;
+import com.kop.daegudot.Network.User.UserOauthResponse;
 import com.kop.daegudot.Network.User.UserRegister;
 import com.kop.daegudot.Network.User.UserResponseStatus;
 import com.kop.daegudot.R;
@@ -235,15 +236,20 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
     private void oauthGoogle(UserOauth userOauth) {
         RestfulAdapter restfulAdapter = RestfulAdapter.getInstance();
         RestApiService service =  restfulAdapter.getServiceApi(null);
-        Observable<Long> observable = service.oauthGoogle(userOauth);
+        Observable<UserOauthResponse> observable = service.oauthGoogle(userOauth);
 
         mCompositeDisposable.add(observable.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(new DisposableObserver<Long>() {
+                .subscribeWith(new DisposableObserver<UserOauthResponse>() {
                     @Override
-                    public void onNext(Long response) {
+                    public void onNext(UserOauthResponse response) {
                         Log.d("USER_GOOGLE", userOauth.oauthToken);
-                        if(response == 1L) Toast.makeText(getApplicationContext(), "구글 인증이 완료되었습니다.", Toast.LENGTH_SHORT).show();
+                        if(response.status == 1L) {
+                            Toast.makeText(getApplicationContext(), "구글 인증이 완료되었습니다.", Toast.LENGTH_SHORT).show();
+                            mEmail = response.email;
+                            mNickname = response.nickname;
+                            selectEmail(mEmail);
+                        }
                         else Toast.makeText(getApplicationContext(), "구글 인증에 실패하였습니다.", Toast.LENGTH_SHORT).show();
                     }
 
@@ -256,7 +262,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                     @Override
                     public void onComplete() {
                         Log.d("USER_GOOGLE", "COMPLETE");
-                        firebaseAuthWithGoogle(userOauth.oauthToken);
+                        //firebaseAuthWithGoogle(userOauth.oauthToken);
                     }
                 })
         );

--- a/app/src/main/java/com/kop/daegudot/Login/LoginActivity.java
+++ b/app/src/main/java/com/kop/daegudot/Login/LoginActivity.java
@@ -170,6 +170,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
             Intent intent = new Intent(getApplicationContext(), SignUpAddInfoActivity.class);
             intent.putExtra("email", mEmail);
             intent.putExtra("nickname", mNickname);
+            intent.putExtra("type", 'G');
             startActivity(intent);
             finish();
         }
@@ -243,7 +244,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                 .subscribeWith(new DisposableObserver<UserOauthResponse>() {
                     @Override
                     public void onNext(UserOauthResponse response) {
-                        Log.d("USER_GOOGLE", userOauth.oauthToken);
+                        Log.d("USER_GOOGLE" + response.status, userOauth.oauthToken);
                         if(response.status == 1L) {
                             Toast.makeText(getApplicationContext(), "구글 인증이 완료되었습니다.", Toast.LENGTH_SHORT).show();
                             mEmail = response.email;
@@ -279,7 +280,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                 .subscribeWith(new DisposableObserver<UserResponseStatus>() {
                     @Override
                     public void onNext(UserResponseStatus response) {
-                        if(response.status == 1L){
+                        if(response.status == 1L && response.userResponseDto.type == 'G'){
                             Toast.makeText(getApplicationContext(), "로그인에 성공하였습니다.", Toast.LENGTH_SHORT).show();
                             Log.d("EMAIl_DUP", "DUPLICATE EMAIL" + " " + response.userResponseDto.email);
 
@@ -290,6 +291,9 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                             editor.apply();
 
                             convertToMainActivity();
+                        }
+                        else{
+                            Toast.makeText(getApplicationContext(), "동일한 이메일이 존재합니다. 다른 로그인 방식을 시도해주세요.", Toast.LENGTH_SHORT).show();
                         }
                     }
 

--- a/app/src/main/java/com/kop/daegudot/Login/SignUpAddInfoActivity.java
+++ b/app/src/main/java/com/kop/daegudot/Login/SignUpAddInfoActivity.java
@@ -39,6 +39,7 @@ public class SignUpAddInfoActivity extends AppCompatActivity implements View.OnC
     SharedPreferences mTokenPref;
     String mNickname;
     String mEmail;
+    char mType;
 
     boolean NICK_CHECKED = false;
 
@@ -50,6 +51,7 @@ public class SignUpAddInfoActivity extends AppCompatActivity implements View.OnC
         Intent intent = getIntent();
         mNickname = intent.getStringExtra("nickname");
         mEmail = intent.getStringExtra("email");
+        mType = intent.getCharExtra("type", 'N');
 
         editName = findViewById(R.id.edit_nickName);
         editName.setText(mNickname);
@@ -148,7 +150,7 @@ public class SignUpAddInfoActivity extends AppCompatActivity implements View.OnC
                         userRegister.email = mEmail;
                         userRegister.nickname = mNickname;
                         userRegister.password = "";
-                        userRegister.type = 'D';
+                        userRegister.type = mType;
 
                         insertUser(userRegister);
 

--- a/app/src/main/java/com/kop/daegudot/Network/RestApiService.java
+++ b/app/src/main/java/com/kop/daegudot/Network/RestApiService.java
@@ -178,7 +178,4 @@ public interface RestApiService {
 
     @POST("/user/register/kakao")
     Observable<UserOauthResponse> oauthKakao(@Body UserOauth userOauth);
-
-    @POST("/user/register/kakao")
-    Observable<Long> oauthKakao(@Body UserOauth userOauth);
 }

--- a/app/src/main/java/com/kop/daegudot/Network/RestApiService.java
+++ b/app/src/main/java/com/kop/daegudot/Network/RestApiService.java
@@ -18,6 +18,7 @@ import com.kop.daegudot.Network.More.MyInfo.NicknameUpdate;
 import com.kop.daegudot.Network.More.MyInfo.PasswordUpdate;
 import com.kop.daegudot.Network.Schedule.SubScheduleResponseList;
 import com.kop.daegudot.Network.User.UserOauth;
+import com.kop.daegudot.Network.User.UserOauthResponse;
 import com.kop.daegudot.Network.User.UserRegister;
 import com.kop.daegudot.Network.User.UserLogin;
 import com.kop.daegudot.Network.User.UserResponse;
@@ -173,7 +174,10 @@ public interface RestApiService {
     Observable<MyCommentList> selectMyComments();
 
     @POST("/user/register/google")
-    Observable<Long> oauthGoogle(@Body UserOauth userOauth);
+    Observable<UserOauthResponse> oauthGoogle(@Body UserOauth userOauth);
+
+    @POST("/user/register/kakao")
+    Observable<UserOauthResponse> oauthKakao(@Body UserOauth userOauth);
 
     @POST("/user/register/kakao")
     Observable<Long> oauthKakao(@Body UserOauth userOauth);

--- a/app/src/main/java/com/kop/daegudot/Network/User/UserOauthResponse.java
+++ b/app/src/main/java/com/kop/daegudot/Network/User/UserOauthResponse.java
@@ -1,0 +1,7 @@
+package com.kop.daegudot.Network.User;
+
+public class UserOauthResponse {
+    public long status;
+    public String email;
+    public String nickname;
+}


### PR DESCRIPTION
1. 카카오 로그인에 필요한 모든 기능 구현
2. 구글이랑 카카오 로그인 이메일 중복되는 경우 구분 by type
3. 구글이랑 카카오 로그인에서 회원가입 할 때 type도 intent로 넘기도록 수정